### PR TITLE
User profile button linked to repo site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
 
         {% if site.github.is_user_page %}
           <ul>
-            <li><a class="buttons github" href="{{ site.github.repository_url }}">GitHub Profile</a></li>
+            <li><a class="buttons github" href="{{ site.github.owner_url }}">GitHub Profile</a></li>
           </ul>
         {% endif %}
       </header>


### PR DESCRIPTION
In instances where one used the dinky theme on a user page, a button is provided, the text of which implies it is to link to the owner's github user profile.

In the _layouts/default.html the case where site.github.is_user_page is true links the button to the repository url, making it a duplicate of the View On GitHub button above it. 
