### PR TITLE
Fixed display of emojis

### DIFF
--- a/_sass/jekyll-theme-dinky.scss
+++ b/_sass/jekyll-theme-dinky.scss
@@ -151,7 +151,7 @@ img {
   border: 1px solid #ccc;
 }
 
-p img {
+p img, .emoji {
   display: inline;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Emojis are supported on GitHub Pages using: https://github.com/jekyll/jemoji
But they are being treated like any other image in this template, which means they're not displayed properly when used in inline text in anything other than a paragraph (see https://modofun.js.org for an example).

Now:
<img width="668" alt="screen shot 2017-11-13 at 11 10 58" src="https://user-images.githubusercontent.com/4420151/32720334-8fc975b2-c863-11e7-8250-81336f97fa81.png">
After change:
<img width="668" alt="screen shot 2017-11-13 at 11 10 35" src="https://user-images.githubusercontent.com/4420151/32720338-94a1d6ba-c863-11e7-9c3a-6253608dc269.png">

Emojis have their own class ("emoji"), so I simply added that class to the same style as inline images in a paragraph. This way they will always be rendered properly, even when used in headings, tables, etc.

Could also add instead ", h1, h2, h3, h4, h5, h6" for example if you prefer to make it class independent, and then any inline image is rendered correctly in headings.