### PR TITLE
Avoid "Flash of Invisible Text" with`display=swap`

### DIFF
--- a/_sass/jekyll-theme-dinky.scss
+++ b/_sass/jekyll-theme-dinky.scss
@@ -1,5 +1,5 @@
 @import "rouge-github";
-@import url('https://fonts.googleapis.com/css?family=Arvo:400,700,400italic');
+@import url('https://fonts.googleapis.com/css?family=Arvo:400,700,400italic&display=swap');
 
 /* MeyerWeb Reset */
 


### PR DESCRIPTION
Google now allows you to provide a `display` parameter when importing fonts and uses that value for the `@font-face` `font-display` descriptor. This tells the browser how to display the font if it's not yet downloaded. Google now defaults to `display=swap`, which displays fonts using a fallback at first, then swaps in the requested font once it is loaded.

More info: https://developers.google.com/web/updates/2016/02/font-display