### PR TITLE
Allow individual pages to specify their own `title` and `description`.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,9 +16,9 @@
   <body>
     <div class="wrapper">
       <header>
-        <h1 class="header">{{ site.title | default: site.github.repository_name }}</h1>
-        <p class="header">{{ site.description | default: site.github.project_tagline }}</p>
-
+        <h1 class="header">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+        <p class="header">{{ page.description | default: site.description | default: site.github.project_tagline }}</p>
+        
         <ul>
           {% if site.show_downloads %}
             <li class="download"><a class="buttons" href="{{ site.github.zip_url }}">Download ZIP</a></li>


### PR DESCRIPTION
This pull request is basically just a copy of [PR #64](https://github.com/pages-themes/cayman/pull/64) from the Cayman theme. Please see the Cayman PR for more information.

Note: I'm not sure how to test this myself but it is simple enough that I feel fairly confident it should work.