### PR TITLE
Leverage font-display: swap mode of Google fonts

### DIFF
--- a/_sass/jekyll-theme-dinky.scss
+++ b/_sass/jekyll-theme-dinky.scss
@@ -1,5 +1,5 @@
 @import "rouge-github";
-@import url('https://fonts.googleapis.com/css?family=Arvo:400,700,400italic');
+@import url('https://fonts.googleapis.com/css?family=Arvo:400,700,400italic&display=swap');
 
 /* MeyerWeb Reset */
 


### PR DESCRIPTION
For performance reasons it is best to use `font-display: swap` and Google Fonts supports this via a URL param. See: https://web.dev/font-display/?utm_source=lighthouse&utm_medium=lr#google-fonts for more info. 

I think it would be wise to add this to the template as the lack of it gets a page a significant ding in web performance measurement. 